### PR TITLE
Add overlay to Ring of Recoil

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemChargeConfig.java
@@ -89,7 +89,7 @@ public interface ItemChargeConfig extends Config
 
 	@ConfigItem(
 		keyName = "showDodgyCount",
-		name = "Dodgy Necklace Count",
+		name = "Show Dodgy Necklace Charges",
 		description = "Configures if Dodgy Necklace charge count is shown",
 		position = 6
 	)
@@ -128,10 +128,50 @@ public interface ItemChargeConfig extends Config
 	void dodgyNecklace(int dodgyNecklace);
 
 	@ConfigItem(
-		keyName = "showImpCharges",
-		name = "Show Imp-in-a-box charges",
-		description = "Configures if imp-in-a-box item charges is shown",
+		keyName = "showRingOfRecoilCount",
+		name = "Show Ring of Recoil Charges",
+		description = "Configures if Ring of Recoil charge count is shown",
 		position = 8
+	)
+	default boolean showRecoilCount()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "recoilNotification",
+		name = "Ring of Recoil Notification",
+		description = "Configures if the Ring of Recoil breaking notification is shown",
+		position = 9
+	)
+	default boolean recoilNotification()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "ringOfRecoil",
+		name = "",
+		description = "",
+		hidden = true
+	)
+	default int ringOfRecoil()
+	{
+		return -1;
+	}
+
+	@ConfigItem(
+		keyName = "ringOfRecoil",
+		name = "",
+		description = ""
+	)
+	void ringOfRecoil(int charges);
+
+	@ConfigItem(
+		keyName = "showImpCharges",
+		name = "Show Imp-in-a-box Charges",
+		description = "Configures if imp-in-a-box item charges is shown",
+		position = 10
 	)
 	default boolean showImpCharges()
 	{
@@ -142,7 +182,7 @@ public interface ItemChargeConfig extends Config
 		keyName = "showFungicideCharges",
 		name = "Show Fungicide Charges",
 		description = "Configures if fungicide item charges is shown",
-		position = 9
+		position = 11
 	)
 	default boolean showFungicideCharges()
 	{
@@ -153,7 +193,7 @@ public interface ItemChargeConfig extends Config
 		keyName = "showWateringCanCharges",
 		name = "Show Watering Can Charges",
 		description = "Configures if watering can item charge is shown",
-		position = 10
+		position = 12
 	)
 	default boolean showWateringCanCharges()
 	{
@@ -164,21 +204,11 @@ public interface ItemChargeConfig extends Config
 		keyName = "showWaterskinCharges",
 		name = "Show Waterskin Charges",
 		description = "Configures if waterskin item charge is shown",
-		position = 11
+		position = 13
 	)
 	default boolean showWaterskinCharges()
 	{
 		return true;
 	}
 
-	@ConfigItem(
-		keyName = "recoilNotification",
-		name = "Ring of Recoil Notification",
-		description = "Configures if the ring of recoil breaking notification is shown",
-		position = 12
-	)
-	default boolean recoilNotification()
-	{
-		return false;
-	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemConfigRegistry.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemConfigRegistry.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.itemcharges;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.Data;
+import net.runelite.client.Notifier;
+
+/**
+ * Allows the various {@link ItemWithVarCharge} items to be handled in the same way, regardless if configuration
+ * for said element exists. All items can invoke the same methods, useful in cases such as the "check" option which all
+ * use the server message. When a callback has not been configured, it defaults to a sensible default.
+ */
+@Singleton
+class ItemConfigRegistry
+{
+	private final Map<ItemWithVarCharge, CallbackRegistry> CALLBACK_REGISTRY;
+
+	@Inject
+	private ItemConfigRegistry(ItemChargeConfig config, Notifier notifier)
+	{
+		CALLBACK_REGISTRY = Arrays.stream(ItemWithVarCharge.values())
+			.collect(Collectors.toMap(Function.identity(),
+				item -> new CallbackRegistry(),
+				(l, r) ->
+				{
+					throw new IllegalArgumentException(String.format("Duplicate keys found for [%s] and [%s]", l, r));
+				},
+				() -> new EnumMap<>(ItemWithVarCharge.class)));
+
+		registerChargesConsumer(ItemWithVarCharge.DODGY_NECKLACE, config::dodgyNecklace);
+		registerChargesSupplier(ItemWithVarCharge.DODGY_NECKLACE, config::dodgyNecklace);
+		registerRenderChargesSupplier(ItemWithVarCharge.DODGY_NECKLACE, config::showDodgyCount);
+		registerSendNotificationSupplier(ItemWithVarCharge.DODGY_NECKLACE, config::dodgyNotification);
+		registerNotificationConsumer(ItemWithVarCharge.DODGY_NECKLACE, notifier::notify);
+
+		registerChargesConsumer(ItemWithVarCharge.RING_OF_RECOIL, config::ringOfRecoil);
+		registerChargesSupplier(ItemWithVarCharge.RING_OF_RECOIL, config::ringOfRecoil);
+		registerRenderChargesSupplier(ItemWithVarCharge.RING_OF_RECOIL, config::showRecoilCount);
+		registerSendNotificationSupplier(ItemWithVarCharge.RING_OF_RECOIL, config::recoilNotification);
+		registerNotificationConsumer(ItemWithVarCharge.RING_OF_RECOIL, notifier::notify);
+	}
+
+	private void registerChargesConsumer(ItemWithVarCharge itemType, Consumer<Integer> chargeConsumer)
+	{
+		CALLBACK_REGISTRY.get(itemType).setChargesConsumer(chargeConsumer);
+	}
+
+	private void registerRenderChargesSupplier(ItemWithVarCharge itemType, Supplier<Boolean> renderSupplier)
+	{
+		CALLBACK_REGISTRY.get(itemType).setRenderChargesSupplier(renderSupplier);
+	}
+
+	private void registerChargesSupplier(ItemWithVarCharge itemType, Supplier<Integer> chargesSupplier)
+	{
+		CALLBACK_REGISTRY.get(itemType).setChargesSupplier(chargesSupplier);
+	}
+
+	private void registerNotificationConsumer(ItemWithVarCharge itemType, Consumer<String> notificationConsumer)
+	{
+		CALLBACK_REGISTRY.get(itemType).setNotificationConsumer(notificationConsumer);
+	}
+
+	private void registerSendNotificationSupplier(ItemWithVarCharge itemType, Supplier<Boolean> sendNotificationSupplier)
+	{
+		CALLBACK_REGISTRY.get(itemType).setSendNotificationSupplier(sendNotificationSupplier);
+	}
+
+	void setCharges(ItemWithVarCharge itemType, Integer charges)
+	{
+		CALLBACK_REGISTRY.get(itemType)
+			.getChargesConsumer()
+			.ifPresent(c -> c.accept(charges));
+	}
+
+	boolean mayRender(ItemWithVarCharge itemType)
+	{
+		return CALLBACK_REGISTRY.get(itemType)
+			.getRenderChargesSupplier()
+			.orElse(() -> false)
+			.get();
+	}
+
+	int getCharges(ItemWithVarCharge itemType)
+	{
+		return CALLBACK_REGISTRY.get(itemType)
+			.getChargesSupplier()
+			.orElse(() -> -1)
+			.get();
+	}
+
+	void sendNotificationIfEnabled(ItemWithVarCharge itemType, String notification)
+	{
+		if (maySendNotification(itemType))
+		{
+			CALLBACK_REGISTRY.get(itemType)
+				.getNotificationConsumer()
+				.ifPresent(c -> c.accept(notification));
+		}
+	}
+
+	private boolean maySendNotification(ItemWithVarCharge itemType)
+	{
+		return CALLBACK_REGISTRY.get(itemType)
+			.getSendNotificationSupplier()
+			.orElse(() -> false)
+			.get();
+	}
+
+
+	@Data
+	private static final class CallbackRegistry
+	{
+		private Consumer<Integer> chargesConsumer;
+		private Supplier<Integer> chargesSupplier;
+		private Supplier<Boolean> renderChargesSupplier;
+
+		private Consumer<String> notificationConsumer;
+		private Supplier<Boolean> sendNotificationSupplier;
+
+		private Optional<Consumer<Integer>> getChargesConsumer()
+		{
+			return Optional.ofNullable(chargesConsumer);
+		}
+
+		private Optional<Supplier<Integer>> getChargesSupplier()
+		{
+			return Optional.ofNullable(chargesSupplier);
+		}
+
+		private Optional<Supplier<Boolean>> getRenderChargesSupplier()
+		{
+			return Optional.ofNullable(renderChargesSupplier);
+		}
+
+		private Optional<Consumer<String>> getNotificationConsumer()
+		{
+			return Optional.ofNullable(notificationConsumer);
+		}
+
+		private Optional<Supplier<Boolean>> getSendNotificationSupplier()
+		{
+			return Optional.ofNullable(sendNotificationSupplier);
+		}
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemWithVarCharge.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/ItemWithVarCharge.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.itemcharges;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.runelite.api.ItemID;
+
+@Getter
+@AllArgsConstructor
+public enum ItemWithVarCharge
+{
+	DODGY_NECKLACE(ItemID.DODGY_NECKLACE, 10,
+		Pattern.compile("Your dodgy necklace.* (\\d+) charges? left.*")),
+	RING_OF_RECOIL(ItemID.RING_OF_RECOIL, 40,
+		Pattern.compile("You can inflict (\\d+) more points of damage before a ring will shatter."));
+
+	private final int itemId;
+	private final int chargesOnDepletion;
+	private final Pattern checkPattern;
+
+	int getCharges(String message)
+	{
+		final Matcher updateMatcher = checkPattern.matcher(message);
+		return updateMatcher.matches() ? Integer.parseInt(updateMatcher.group(1)) : -1;
+	}
+
+	static Optional<ItemWithVarCharge> forId(int itemId)
+	{
+		return Arrays.stream(values())
+			.filter(item -> item.getItemId() == itemId)
+			.findFirst();
+	}
+
+	static Optional<ItemWithVarCharge> forOnCheckMessage(String message)
+	{
+		return Arrays.stream(values())
+			.filter(item -> item.getCheckPattern().matcher(message).matches())
+			.findFirst();
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/recoil/RecoilManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/itemcharges/recoil/RecoilManager.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.itemcharges.recoil;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.Hitsplat;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.NPC;
+import net.runelite.api.NpcID;
+import net.runelite.client.plugins.itemcharges.ItemWithVarCharge;
+
+@Slf4j
+public class RecoilManager
+{
+	private static final MaxCapacityMap<Integer, List<Integer>> PLAYER_HITSPLATS_PER_TICK = new MaxCapacityMap<>();
+	private static final int MAX_TICKS_EARLIER = 10;
+	private static final Set<Integer> SNAKELING_IDS = ImmutableSet.of(
+		NpcID.SNAKELING, NpcID.SNAKELING_2127, NpcID.SNAKELING_2128, NpcID.SNAKELING_2129, NpcID.SNAKELING_2130,
+		NpcID.SNAKELING_2131, NpcID.SNAKELING_2132, NpcID.SNAKELING_2046, NpcID.SNAKELING_2047);
+
+	private final Client client;
+
+	@Inject
+	private RecoilManager(Client client)
+	{
+		this.client = client;
+	}
+
+	public void addPlayerHitsplat(Hitsplat hitsplat)
+	{
+		final ItemContainer itemContainer = client.getItemContainer(InventoryID.EQUIPMENT);
+		if (itemContainer == null)
+		{
+			return;
+		}
+
+		final Item equippedRing = itemContainer.getItems()[EquipmentInventorySlot.RING.getSlotIdx()];
+		if (equippedRing == null || equippedRing.getId() != ItemWithVarCharge.RING_OF_RECOIL.getItemId())
+		{
+			return;
+		}
+
+		if (hitsplat.getAmount() > 0 && hitsplat.getHitsplatType() == Hitsplat.HitsplatType.DAMAGE)
+		{
+			final int currentTick = client.getTickCount();
+			log.debug("Player received hitsplat [{}] on tick [{}].", hitsplat.getAmount(), currentTick);
+			PLAYER_HITSPLATS_PER_TICK.putIfAbsent(currentTick, new ArrayList<>());
+			PLAYER_HITSPLATS_PER_TICK.get(currentTick).add(hitsplat.getAmount());
+		}
+	}
+
+	public Optional<Integer> reduceChargesForOpponentHitsplat(Actor opponent, Hitsplat opponentHitsplat)
+	{
+		if (opponentHitsplat.getAmount() <= 0 || opponentHitsplat.getHitsplatType() != Hitsplat.HitsplatType.DAMAGE)
+		{
+			return Optional.empty();
+		}
+
+		final int currentTick = client.getTickCount();
+		log.debug("Actor [{}] received hitsplat [{}] on tick [{}].", opponent.getName(), opponentHitsplat.getAmount(), currentTick);
+
+		final Optional<Integer> consumedHitsplat = PLAYER_HITSPLATS_PER_TICK.entrySet().stream()
+			.filter(pEntry -> pEntry.getKey() >= currentTick - MAX_TICKS_EARLIER)
+			.flatMap(pEntry -> pEntry.getValue().stream())
+			.filter(playerHit -> wasProbableCause(playerHit, opponentHitsplat.getAmount(), opponent))
+			.findFirst();
+
+		consumedHitsplat.ifPresent(this::removeConsumedHitsplat);
+
+		return consumedHitsplat.map(playerHitsplat -> mapToChargeReduction(playerHitsplat, opponent));
+	}
+
+	private void removeConsumedHitsplat(int playerHitsplat)
+	{
+		for (List<Integer> hitsplatsPerTick : PLAYER_HITSPLATS_PER_TICK.values())
+		{
+			final Iterator<Integer> hitsplatIterator = hitsplatsPerTick.iterator();
+			while (hitsplatIterator.hasNext())
+			{
+				final Integer nextHitsplat = hitsplatIterator.next();
+				if (playerHitsplat == nextHitsplat)
+				{
+					hitsplatIterator.remove();
+					return;
+				}
+			}
+		}
+	}
+
+	private int mapToChargeReduction(Integer playerHit, Actor opponent)
+	{
+		if (isSnakeling(opponent))
+		{
+			return 1;
+		}
+
+		return calculateChargeReduction(playerHit);
+	}
+
+	private boolean wasProbableCause(Integer playerHit, int opponentHit, Actor opponent)
+	{
+		if (isSnakeling(opponent))
+		{
+			return true;
+		}
+
+		final int chargeReduction = calculateChargeReduction(playerHit);
+		return opponentHit == chargeReduction;
+	}
+
+	/**
+	 * Calculates the charges that would be reduced for the hitsplat received by the player. Charges used is 10% of
+	 * damage received, rounded up to the nearest integer. Except when the recoil damage would be greater than the health
+	 * of the opponent (such as Snakelings), in which the charges reduced is the remaining health of the opponent.
+	 * Every 10th increment also changes the threshold. E.g.: 10 hitsplat = 2 charges, 20 hitsplat = 3 charges, ...
+	 *
+	 * @param hitsplat the hitsplat received by the player for which the charge reduction should be calculated
+	 * @return the charges that should be reduced based on the received hitsplat
+	 */
+	private int calculateChargeReduction(int hitsplat)
+	{
+		return hitsplat == 0 ? 0 : (int) Math.ceil((hitsplat + 1) * 0.1);
+	}
+
+	private boolean isSnakeling(Actor actor)
+	{
+		if (!(actor instanceof NPC))
+		{
+			return false;
+		}
+
+		final int npcId = ((NPC) actor).getComposition().getId();
+		return SNAKELING_IDS.contains(npcId);
+	}
+
+	/**
+	 * Implementation of a {@link LinkedHashMap} which overrides the {@link #removeEldestEntry(Map.Entry)} method.
+	 * It allows its eldest entries to be auto-removed after its max capacity has been reached.
+	 *
+	 * @param <K> the type of keys maintained by this map
+	 * @param <V> the type of mapped values
+	 */
+	private static class MaxCapacityMap<K, V> extends LinkedHashMap<K, V>
+	{
+		private static final int MAX_ENTRIES = 5;
+
+		@Override
+		protected boolean removeEldestEntry(Map.Entry<K, V> eldest)
+		{
+			return size() > MAX_ENTRIES;
+		}
+	}
+}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/itemcharges/ItemChargePluginTest.java
@@ -30,23 +30,21 @@ import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.ItemComposition;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.client.Notifier;
 import net.runelite.client.ui.overlay.OverlayManager;
-import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ItemChargePluginTest
 {
-	private static final String CHECK = "Your dodgy necklace has 10 charges left.";
-	private static final String PROTECT = "Your dodgy necklace protects you. It has 9 charges left.";
-	private static final String PROTECT_1 = "Your dodgy necklace protects you. <col=ff0000>It has 1 charge left.</col>";
-	private static final String BREAK = "Your dodgy necklace protects you. <col=ff0000>It then crumbles to dust.</col>";
 
 	@Mock
 	@Bind
@@ -58,11 +56,11 @@ public class ItemChargePluginTest
 
 	@Mock
 	@Bind
-	private Notifier notifier;
+	private ItemChargeConfig itemChargeConfig;
 
 	@Mock
 	@Bind
-	private ItemChargeConfig config;
+	private ItemConfigRegistry registry;
 
 	@Inject
 	private ItemChargePlugin itemChargePlugin;
@@ -74,22 +72,50 @@ public class ItemChargePluginTest
 	}
 
 	@Test
-	public void testOnChatMessage()
+	public void dodgyChecksOnExamine()
 	{
-		ChatMessage chatMessage = new ChatMessage(ChatMessageType.SERVER, "", CHECK, "");
+		String dodgyCheck = "Your dodgy necklace has 10 charges left.";
+		ChatMessage chatMessage = new ChatMessage(ChatMessageType.SERVER, "", dodgyCheck, "");
 		itemChargePlugin.onChatMessage(chatMessage);
-		assertEquals(10, itemChargePlugin.getDodgyCharges());
+		verify(registry).setCharges(ItemWithVarCharge.DODGY_NECKLACE, 10);
+	}
 
-		chatMessage = new ChatMessage(ChatMessageType.SERVER, "", PROTECT, "");
+	@Test
+	public void dodgyChecksOnProtect()
+	{
+		String dodgyProtect = "Your dodgy necklace protects you. It has 9 charges left.";
+		ChatMessage chatMessage = new ChatMessage(ChatMessageType.SERVER, "", dodgyProtect, "");
 		itemChargePlugin.onChatMessage(chatMessage);
-		assertEquals(9, itemChargePlugin.getDodgyCharges());
+		verify(registry).setCharges(ItemWithVarCharge.DODGY_NECKLACE, 9);
+	}
 
-		chatMessage = new ChatMessage(ChatMessageType.SERVER, "", PROTECT_1, "");
+	@Test
+	public void dodgyChecksOnOneLeft()
+	{
+		String dodgyProtect1 = "Your dodgy necklace protects you. <col=ff0000>It has 1 charge left.</col>";
+		ChatMessage chatMessage = new ChatMessage(ChatMessageType.SERVER, "", dodgyProtect1, "");
 		itemChargePlugin.onChatMessage(chatMessage);
-		assertEquals(1, itemChargePlugin.getDodgyCharges());
+		verify(registry).setCharges(ItemWithVarCharge.DODGY_NECKLACE, 1);
+	}
 
-		chatMessage = new ChatMessage(ChatMessageType.SERVER, "", BREAK, "");
+	@Test
+	public void dodgyChecksOnDepletionAndNotifies()
+	{
+		String dodgyBreak = "Your dodgy necklace protects you. <col=ff0000>It then crumbles to dust.</col>";
+		ItemComposition itemCompMock = Mockito.mock(ItemComposition.class);
+		when(itemCompMock.getName()).thenReturn("Dodgy necklace");
+		ChatMessage chatMessage = new ChatMessage(ChatMessageType.SERVER, "", dodgyBreak, "");
 		itemChargePlugin.onChatMessage(chatMessage);
-		assertEquals(10, itemChargePlugin.getDodgyCharges());
+		verify(registry).setCharges(ItemWithVarCharge.DODGY_NECKLACE, 10);
+		verify(registry).sendNotificationIfEnabled(ItemWithVarCharge.DODGY_NECKLACE, "Your Dodgy Necklace has crumbled to dust.");
+	}
+
+	@Test
+	public void ringOfRecoilChecksOnExamine()
+	{
+		String recoilCheck = "You can inflict 32 more points of damage before a ring will shatter.";
+		ChatMessage chatMessage = new ChatMessage(ChatMessageType.SERVER, "", recoilCheck, "");
+		itemChargePlugin.onChatMessage(chatMessage);
+		verify(registry).setCharges(ItemWithVarCharge.RING_OF_RECOIL, 32);
 	}
 }


### PR DESCRIPTION
Initial commit to add a charges overlay to the Ring of Recoil.
Currently, there is no way to find out the source actor of hitsplats.
This implementation is based solely on assumptions. Namely, if the
player has been hit while wearing the ring of recoil, and the opponent
receives a hitsplat within 10 ticks which matches the calculated
reduction, charges are reduced from the ring. This works 90% fine on
Zulrah, but has issues on other events like Pest Control.

Implements #2109

Signed-off-by: Jaimy Smets <smets.jaimy@hotmail.com>